### PR TITLE
Prevent validation of SSL certificate

### DIFF
--- a/PyCon15ToGCal/pycon_parser.py
+++ b/PyCon15ToGCal/pycon_parser.py
@@ -133,7 +133,6 @@ def make_tree(url):
     :param str url: The URL of all the events.
     :return: A ``lxml.tree``
     """
-    # response = requests.get(url, verify=False).text
-    response = requests.get(url).text
+    response = requests.get(url, verify=False).text
     tree = html.fromstring(response)
     return tree


### PR DESCRIPTION
I notice you had commented out the line to prevent validation of the Pycon SSL certificate - the script didn't work for me, and errored with:

requests.exceptions.SSLError: hostname 'us.pycon.org' doesn't match either of '*.python.org', 

I've changed it back to verify=False and it works OK now.
